### PR TITLE
u-boot: updated to v2020.07 for revD1 support

### DIFF
--- a/recipes-bsp/u-boot/files/0001-Add-FAT-write-support.patch
+++ b/recipes-bsp/u-boot/files/0001-Add-FAT-write-support.patch
@@ -1,4 +1,4 @@
-From 8e217298f7fda5d29d599cfe19393312f0dcc5b7 Mon Sep 17 00:00:00 2001
+From 18df817c188bcd850067244ae761106a158ab138 Mon Sep 17 00:00:00 2001
 From: Scott Ellis <scott@jumpnowtek.com>
 Date: Sat, 14 Dec 2019 07:09:49 -0500
 Subject: [PATCH] Add FAT write support
@@ -8,11 +8,11 @@ Subject: [PATCH] Add FAT write support
  1 file changed, 1 insertion(+)
 
 diff --git a/configs/wandboard_defconfig b/configs/wandboard_defconfig
-index ca564c59b8..86f6aa70c7 100644
+index 733b4e82ed..5f1fb75ebc 100644
 --- a/configs/wandboard_defconfig
 +++ b/configs/wandboard_defconfig
 @@ -75,3 +75,4 @@ CONFIG_DM_VIDEO=y
- CONFIG_VIDEO_BPP16=y
+ # CONFIG_VIDEO_BPP32 is not set
  CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_VIDEO_IPUV3=y
 +CONFIG_FAT_WRITE=y

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -2,6 +2,10 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://0001-Add-FAT-write-support.patch"
 
+# v2020.07
+PV="2020.07"
+SRCREV="2f5fbb5b39f7b67044dda5c35e4a4b31685a3109"
+
 UBOOT_LOCALVERSION = "-jumpnow"
 
 UBOOT_SUFFIX = "img"


### PR DESCRIPTION
Hi, this works for my Wandboard rev. D1 with a i.MX Quad. The PMIC is correctly detected.
I cannot test any other board revision.