### PR TITLE
Enable wic file

### DIFF
--- a/conf/machine/wandboard.conf
+++ b/conf/machine/wandboard.conf
@@ -25,8 +25,10 @@ EXTRA_IMAGEDEPENDS += "u-boot"
 
 SERIAL_CONSOLES = "115200;ttymxc0"
 
-IMAGE_FSTYPES = "tar.xz"
+IMAGE_FSTYPES = "tar.xz ext4 wic.bz2 wic.bmap"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "kernel-image kernel-devicetree kernel-modules"
 
 MACHINE_FEATURES = "ext2 serial usbhost vfat"
+
+WKS_FILE ?= "wandboard.wks.in"

--- a/wic/wandboard.wks.in
+++ b/wic/wandboard.wks.in
@@ -1,0 +1,13 @@
+# The disk layout used is:
+#  - ----- --------- --------------
+# | | SPL | u-boot  |    rootfs    |
+#  - ----- --------- --------------
+# ^ ^     ^         ^              
+# | |     |         |              
+# 0 1kiB  69kiB   4MiB rootfs + IMAGE_EXTRA_SPACE (default 10MiB)
+#
+part SPL --source rawcopy --sourceparams="file=SPL" --ondisk mmcblk --no-table --align 1
+part u-boot --source rawcopy --sourceparams="file=u-boot.img" --ondisk mmcblk --no-table --align 69
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096
+
+bootloader --ptable msdos


### PR DESCRIPTION
The wks file defines a wic file that can be written to a SD card directly with e.g.
`bmaptool copy --bmap console-image-wandboard.wic.bmap console-image-wandboard.wic.bz2 /dev/sdX`